### PR TITLE
Added --stdin_devnull flag to command runner that is set when stdin is None

### DIFF
--- a/autograder_sandbox/autograder_sandbox.py
+++ b/autograder_sandbox/autograder_sandbox.py
@@ -9,7 +9,7 @@ from typing import List
 
 import redis
 
-VERSION = '3.1.0'
+VERSION = '3.1.1'
 
 SANDBOX_HOME_DIR_NAME = '/home/autograder'
 SANDBOX_WORKING_DIR_NAME = os.path.join(SANDBOX_HOME_DIR_NAME, 'working_dir')
@@ -227,6 +227,7 @@ class AutograderSandbox:
         :param as_root: Whether to run the command as a root user.
 
         :param stdin: A file object to be redirected as input to the
+            command's stdin. If this is None, /dev/null is sent to the
             command's stdin.
 
         :param timeout: The time limit for the command.
@@ -241,6 +242,9 @@ class AutograderSandbox:
             will be truncated after this many bytes.
         """
         cmd = ['docker', 'exec', '-i', self.name, 'cmd_runner.py']
+
+        if stdin is None:
+            cmd.append('--stdin_devnull')
 
         if max_num_processes is not None:
             cmd += ['--max_num_processes', str(max_num_processes)]

--- a/autograder_sandbox/docker-image-setup/cmd_runner.py
+++ b/autograder_sandbox/docker-image-setup/cmd_runner.py
@@ -50,7 +50,7 @@ def main():
     stderr = b''
     timed_out = False
     return_code = None
-    stdin = subprocess.DEVNULL if args.stdin_devnull else None 
+    stdin = subprocess.DEVNULL if args.stdin_devnull else None
     try:
         with subprocess.Popen(args.cmd_args,
                               stdin=stdin,

--- a/autograder_sandbox/docker-image-setup/cmd_runner.py
+++ b/autograder_sandbox/docker-image-setup/cmd_runner.py
@@ -50,8 +50,10 @@ def main():
     stderr = b''
     timed_out = False
     return_code = None
+    stdin = subprocess.DEVNULL if args.stdin_devnull else None 
     try:
         with subprocess.Popen(args.cmd_args,
+                              stdin=stdin,
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE,
                               preexec_fn=set_subprocess_rlimits,
@@ -111,6 +113,7 @@ def parse_args():
     parser.add_argument("--truncate_stdout", nargs='?', type=int)
     parser.add_argument("--truncate_stderr", nargs='?', type=int)
     parser.add_argument("--linux_user_id", nargs='?', type=int)
+    parser.add_argument("--stdin_devnull", action='store_true', default=False)
     parser.add_argument("cmd_args", nargs=argparse.REMAINDER)
 
     return parser.parse_args()

--- a/autograder_sandbox/tests.py
+++ b/autograder_sandbox/tests.py
@@ -179,6 +179,18 @@ class AutograderSandboxMiscTestCase(unittest.TestCase):
             result = sandbox.run_command(['cat'], stdin=self.stdin)
             self.assertEqual(expected_stdout, result.stdout.read())
 
+    def test_command_tries_to_read_from_stdin_when_stdin_arg_is_none(self):
+        with AutograderSandbox() as sandbox:
+            result = sandbox.run_command(
+                ['python3', '-c', "import sys; sys.stdin.read(); print('done')"],
+                max_num_processes=10,
+                max_stack_size=10000000,
+                max_virtual_memory=500000000,
+                timeout=2,
+            )
+            self.assertFalse(result.timed_out)
+            self.assertEqual(0, result.return_code)
+
     def test_return_code_reported_and_stderr_recorded(self):
         with AutograderSandbox() as sandbox:
             result = sandbox.run_command(['ls', 'definitely not a file'])


### PR DESCRIPTION
When this flag is set, the subprocess started by the command runner has
/dev/null redirected to its stdin.

Fixes #20 