### PR TITLE
Updated output handling to be chunked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
     - pip install -r requirements-dev.txt
 
 script:
-    - pycodestyle autograder_sandbox && pydocstyle autograder_sandbox && python3 -m unittest discover
+    - pycodestyle autograder_sandbox && pydocstyle autograder_sandbox && python3 -m unittest discover -v

--- a/autograder_sandbox/autograder_sandbox.py
+++ b/autograder_sandbox/autograder_sandbox.py
@@ -296,17 +296,20 @@ class AutograderSandbox:
             try:
                 subprocess.run(cmd, stdin=stdin, stdout=f, stderr=subprocess.PIPE, check=True)
                 f.seek(0)
+
                 json_len = int(f.readline().decode().rstrip())
                 results_json = json.loads(f.read(json_len).decode())
 
                 stdout_len = int(f.readline().decode().rstrip())
                 stdout = tempfile.NamedTemporaryFile()
-                stdout.write(f.read(stdout_len))
+                for chunk in _chunked_read(f, stdout_len):
+                    stdout.write(chunk)
                 stdout.seek(0)
 
                 stderr_len = int(f.readline().decode().rstrip())
                 stderr = tempfile.NamedTemporaryFile()
-                stderr.write(f.read(stderr_len))
+                for chunk in _chunked_read(f, stderr_len):
+                    stderr.write(chunk)
                 stderr.seek(0)
 
                 result = CompletedCommand(return_code=results_json['return_code'],
@@ -324,11 +327,11 @@ class AutograderSandbox:
                 return result
             except subprocess.CalledProcessError as e:
                 f.seek(0)
+                stderr = e.stderr if isinstance(e.stderr, bytes) else e.stderr.read()
                 raise SandboxCommandError(
                     f.read().decode('utf-8', 'surrogateescape')
                     + '\n'
-                    + e.stdout.read().decode('utf-8', 'surrogateescape')
-                    + e.stderr.read().decode('utf-8', 'surrogateescape')
+                    + stderr.decode('utf-8', 'surrogateescape')
                 ) from e
 
     def add_files(self, *filenames: str, owner: str=SANDBOX_USERNAME, read_only: bool=False):
@@ -383,6 +386,18 @@ class AutograderSandbox:
             'chown', '{}:{}'.format(SANDBOX_USERNAME, SANDBOX_USERNAME)]
         chown_cmd += filenames
         self.run_command(chown_cmd, as_root=True)
+
+
+# Generator that reads amount_to_read bytes from file_obj, yielding
+# one chunk at a time.
+def _chunked_read(file_obj, amount_to_read, chunk_size=1024*16):
+    num_reads = amount_to_read // chunk_size
+    for i in range(num_reads):
+        yield file_obj.read(chunk_size)
+
+    remainder = amount_to_read % chunk_size
+    if remainder:
+        yield file_obj.read(remainder)
 
 
 class CompletedCommand:

--- a/autograder_sandbox/autograder_sandbox.py
+++ b/autograder_sandbox/autograder_sandbox.py
@@ -390,7 +390,7 @@ class AutograderSandbox:
 
 # Generator that reads amount_to_read bytes from file_obj, yielding
 # one chunk at a time.
-def _chunked_read(file_obj, amount_to_read, chunk_size=1024*16):
+def _chunked_read(file_obj, amount_to_read, chunk_size=1024 * 16):
     num_reads = amount_to_read // chunk_size
     for i in range(num_reads):
         yield file_obj.read(chunk_size)

--- a/autograder_sandbox/docker-image-setup/cmd_runner.py
+++ b/autograder_sandbox/docker-image-setup/cmd_runner.py
@@ -45,13 +45,11 @@ def main():
             traceback.print_exc()
             raise
 
-    # Adopted from https://github.com/python/cpython/blob/3.5/Lib/subprocess.py#L378
-    # stdout = b''
-    # stderr = b''
     timed_out = False
     return_code = None
     stdin = subprocess.DEVNULL if args.stdin_devnull else None
     with tempfile.TemporaryFile() as stdout, tempfile.TemporaryFile() as stderr:
+        # Adopted from https://github.com/python/cpython/blob/3.5/Lib/subprocess.py#L378
         try:
             with subprocess.Popen(args.cmd_args,
                                   stdin=stdin,
@@ -61,7 +59,6 @@ def main():
                                   start_new_session=True) as process:
                 try:
                     return_code = process.wait(timeout=args.timeout)
-                    # return_code = process.poll()
                 except subprocess.TimeoutExpired:
                     # http://stackoverflow.com/questions/4789837/how-to-terminate-a-python-subprocess-launched-with-shell-true
                     os.killpg(os.getpgid(process.pid), signal.SIGKILL)
@@ -72,15 +69,6 @@ def main():
                     process.wait()
                     raise
 
-        # if (args.truncate_stdout is not None
-        #         and os.path.getsize(stdout_filename) > args.truncate_stdout):
-        #     os.truncate(stdout_filename, args.truncate_stdout)
-        #     stdout_truncated = True
-
-        # if (args.truncate_stderr is not None
-        #         and os.path.getsize(stderr_filename) > args.truncate_stderr):
-        #     os.truncate(stderr_filename, args.truncate_stderr)
-        #     stderr_truncated = True
         except FileNotFoundError:
             # This is the value returned by /bin/sh when an executable could
             # not be found.
@@ -100,14 +88,6 @@ def main():
             'stderr_truncated': stderr_truncated,
         }
 
-        # if args.truncate_stdout is not None and len(stdout) > args.truncate_stdout:
-        #     stdout = stdout[:args.truncate_stdout]
-        #     results['stdout_truncated'] = True
-
-        # if args.truncate_stderr is not None and len(stderr) > args.truncate_stderr:
-        #     stderr = stderr[:args.truncate_stderr]
-        #     results['stderr_truncated'] = True
-
         json_data = json.dumps(results)
         print(len(json_data), flush=True)
         print(json_data, end='', flush=True)
@@ -125,14 +105,6 @@ def main():
         for chunk in _chunked_read(stderr, truncated_stderr_len):
             sys.stdout.buffer.write(chunk)
             sys.stdout.flush()
-
-        # print(len(stdout), flush=True)
-        # sys.stdout.buffer.write(stdout)
-        # sys.stdout.flush()
-
-        # print(len(stderr), flush=True)
-        # sys.stdout.buffer.write(stderr)
-        # sys.stdout.flush()
 
 
 def parse_args():

--- a/autograder_sandbox/docker-image-setup/cmd_runner.py
+++ b/autograder_sandbox/docker-image-setup/cmd_runner.py
@@ -152,7 +152,7 @@ def parse_args():
 
 # Generator that reads amount_to_read bytes from file_obj, yielding
 # one chunk at a time.
-def _chunked_read(file_obj, amount_to_read, chunk_size=1024*16):
+def _chunked_read(file_obj, amount_to_read, chunk_size=1024 * 16):
     num_reads = amount_to_read // chunk_size
     for i in range(num_reads):
         yield file_obj.read(chunk_size)

--- a/autograder_sandbox/output_size_performance_test.py
+++ b/autograder_sandbox/output_size_performance_test.py
@@ -1,0 +1,52 @@
+import argparse
+import os
+import tempfile
+import time
+
+from autograder_sandbox import AutograderSandbox, SandboxCommandError, VERSION
+
+
+def main():
+    args = parse_args()
+
+    stdin = tempfile.NamedTemporaryFile()
+
+    repeat_str = b'a' * 1000
+    num_repeats = args.output_size // 1000
+    remainder = args.output_size % 1000
+    for i in range(num_repeats):
+        stdin.write(repeat_str)
+    stdin.write(b'a' * remainder)
+
+    with AutograderSandbox() as sandbox:
+        stdin.seek(0)
+        start = time.time()
+        result = sandbox.run_command(['cat'], stdin=stdin)
+        print('Ran command that read and printed {} bytes to stdout in {}'.format(
+            args.output_size, time.time() - start))
+        stdout_size = os.path.getsize(result.stdout.name)
+        print(stdout_size)
+        assert args.output_size == stdout_size
+
+    if args.stderr:
+        with AutograderSandbox() as sandbox:
+            stdin.seek(0)
+            start = time.time()
+            result = sandbox.run_command(['bash', '-c', '>&2 cat'], stdin=stdin)
+            print('Ran command that read and printed {} bytes to stderr in {}'.format(
+                num_repeats * len(repeat_str), time.time() - start))
+            stderr_size = os.path.getsize(result.stderr.name)
+            print(stderr_size)
+            assert args.output_size == stderr_size
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('output_size', type=int)
+    parser.add_argument('--stderr', action='store_true', default=False)
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    main()

--- a/autograder_sandbox/output_size_performance_test.py
+++ b/autograder_sandbox/output_size_performance_test.py
@@ -8,12 +8,24 @@ from autograder_sandbox import AutograderSandbox, SandboxCommandError, VERSION
 
 def main():
     args = parse_args()
+    output_size_performance_test(args.output_size, args.stderr, args.truncate)
 
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('output_size', type=int)
+    parser.add_argument('--stderr', action='store_true', default=False)
+    parser.add_argument('--truncate', type=int)
+
+    return parser.parse_args()
+
+
+def output_size_performance_test(output_size, *, stderr=True, truncate=None):
     stdin = tempfile.NamedTemporaryFile()
 
     repeat_str = b'a' * 1000
-    num_repeats = args.output_size // 1000
-    remainder = args.output_size % 1000
+    num_repeats = output_size // 1000
+    remainder = output_size % 1000
     for i in range(num_repeats):
         stdin.write(repeat_str)
     stdin.write(b'a' * remainder)
@@ -21,32 +33,54 @@ def main():
     with AutograderSandbox() as sandbox:
         stdin.seek(0)
         start = time.time()
-        result = sandbox.run_command(['cat'], stdin=stdin)
+        result = sandbox.run_command(
+            ['python3', '-c', _STDIN_TO_STDOUT_PROG],
+            stdin=stdin, truncate_stdout=truncate, truncate_stderr=truncate)
         print('Ran command that read and printed {} bytes to stdout in {}'.format(
-            args.output_size, time.time() - start))
+            output_size, time.time() - start))
         stdout_size = os.path.getsize(result.stdout.name)
         print(stdout_size)
-        assert args.output_size == stdout_size
+        if truncate is None:
+            assert stdout_size == output_size
+        else:
+            assert stdout_size == truncate
 
-    if args.stderr:
+    if stderr:
         with AutograderSandbox() as sandbox:
             stdin.seek(0)
             start = time.time()
-            result = sandbox.run_command(['bash', '-c', '>&2 cat'], stdin=stdin)
+            result = sandbox.run_command(
+                ['python3', '-c', _STDIN_TO_STDERR_PROG],
+                stdin=stdin, truncate_stdout=truncate, truncate_stderr=truncate)
             print('Ran command that read and printed {} bytes to stderr in {}'.format(
                 num_repeats * len(repeat_str), time.time() - start))
             stderr_size = os.path.getsize(result.stderr.name)
             print(stderr_size)
-            assert args.output_size == stderr_size
+            if truncate is None:
+                assert stderr_size == output_size
+            else:
+                assert stderr_size == truncate
 
 
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('output_size', type=int)
-    parser.add_argument('--stderr', action='store_true', default=False)
+_STDIN_TO_STDOUT_PROG = """
+import shutil
+import sys
 
-    return parser.parse_args()
+while True:
+    chunk = sys.stdin.read()
+    if not chunk:
+        break
 
+    sys.stdout.write(chunk)
+    sys.stdout.flush()
+"""
+
+_STDIN_TO_STDERR_PROG = """
+import shutil
+import sys
+
+shutil.copyfileobj(sys.stdin, sys.stderr)
+"""
 
 if __name__ == '__main__':
     main()

--- a/autograder_sandbox/tests.py
+++ b/autograder_sandbox/tests.py
@@ -14,6 +14,8 @@ from collections import OrderedDict
 
 from autograder_sandbox import AutograderSandbox, SandboxCommandError, VERSION
 
+from .output_size_performance_test import output_size_performance_test
+
 
 def kb_to_bytes(num_kb):
     return 1000 * num_kb
@@ -122,60 +124,10 @@ class AutograderSandboxMiscTestCase(unittest.TestCase):
         file_obj.seek(0)
 
     def test_very_large_io_no_truncate(self):
-        repeat_str = b'a' * 1000
-        num_repeats = 1000000  # 1 GB
-        for i in range(num_repeats):
-            self.stdin.write(repeat_str)
-        with AutograderSandbox() as sandbox:  # type: AutograderSandbox
-            self.stdin.seek(0)
-            start = time.time()
-            result = sandbox.run_command(['cat'], stdin=self.stdin)
-            self.assertFalse(result.stdout_truncated)
-            self.assertFalse(result.stderr_truncated)
-            print('Ran command that read and printed {} bytes to stdout in {}'.format(
-                num_repeats * len(repeat_str), time.time() - start))
-            stdout_size = os.path.getsize(result.stdout.name)
-            print(stdout_size)
-            self.assertEqual(len(repeat_str) * num_repeats, stdout_size)
-
-        with AutograderSandbox() as sandbox:  # type: AutograderSandbox
-            self.stdin.seek(0)
-            start = time.time()
-            result = sandbox.run_command(['bash', '-c', '>&2 cat'], stdin=self.stdin)
-            print('Ran command that read and printed {} bytes to stderr in {}'.format(
-                num_repeats * len(repeat_str), time.time() - start))
-            stderr_size = os.path.getsize(result.stderr.name)
-            print(stderr_size)
-            self.assertEqual(len(repeat_str) * num_repeats, stderr_size)
+        output_size_performance_test(10 ** 9)
 
     def test_truncate_very_large_io(self) -> None:
-        repeat_str = b'a' * 1000
-        num_repeats = 1000000  # 1 GB
-        truncate_len = 10 ** 7  # 10MB
-        for i in range(num_repeats):
-            self.stdin.write(repeat_str)
-        with AutograderSandbox() as sandbox:  # type: AutograderSandbox
-            self.stdin.seek(0)
-            start = time.time()
-            result = sandbox.run_command(['cat'], stdin=self.stdin, truncate_stdout=truncate_len)
-            self.assertTrue(result.stdout_truncated)
-            self.assertFalse(result.stderr_truncated)
-            print('Ran command that read and printed {} bytes to stdout in {}'.format(
-                num_repeats * len(repeat_str), time.time() - start))
-            stdout_size = os.path.getsize(result.stdout.name)
-            print(stdout_size)
-            self.assertEqual(truncate_len, stdout_size)
-
-        with AutograderSandbox() as sandbox:  # type: AutograderSandbox
-            self.stdin.seek(0)
-            start = time.time()
-            result = sandbox.run_command(
-                ['bash', '-c', '>&2 cat'], stdin=self.stdin, truncate_stderr=truncate_len)
-            print('Ran command that read and printed {} bytes to stderr in {}'.format(
-                num_repeats * len(repeat_str), time.time() - start))
-            stderr_size = os.path.getsize(result.stderr.name)
-            print(stderr_size)
-            self.assertEqual(truncate_len, stderr_size)
+        output_size_performance_test(10 ** 9, truncate=10**7)
 
     def test_truncate_stdout(self):
         truncate_length = 9


### PR DESCRIPTION
Changes:
- cmd_runner.py prints output to stdout in chunks
- AutograderSandbox.run_command function reads output from cmd_runner.py's stdout in chunks
  and writes it to its own storage files in chunks.

While this doesn't provide a noticeable performance improvement for output up to 1GB,
it is safer as it will help us avoid accidentally loading too much output into memory at once.
We didn't test larger values because even 1GB is more output per command that we want to handle,
and processing that much output took about 6 seconds on my desktop.

Fixes #28 