### PR TITLE
Add container-level resource limits

### DIFF
--- a/autograder_sandbox/autograder_sandbox.py
+++ b/autograder_sandbox/autograder_sandbox.py
@@ -111,8 +111,8 @@ class AutograderSandbox:
             The default value for this parameter can be changed by
             setting the SANDBOX_MEM_LIMIT environment variable.
 
-            See https://docs.docker.com/config/containers/resource_constraints/\
-#limit-a-containers-access-to-memory
+            See https://docs.docker.com/config/containers/resource_constraints/
+                    #limit-a-containers-access-to-memory
             for more information.
 
         :param min_fallback_timeout: The timeout argument to run_command

--- a/autograder_sandbox/autograder_sandbox.py
+++ b/autograder_sandbox/autograder_sandbox.py
@@ -19,6 +19,8 @@ SANDBOX_DOCKER_IMAGE = os.environ.get('SANDBOX_DOCKER_IMAGE', 'jameslp/ag-ubuntu
 SANDBOX_PIDS_LIMIT = os.environ.get('SANDBOX_PIDS_LIMIT', 512)
 SANDBOX_MEM_LIMIT = os.environ.get('SANDBOX_MEM_LIMIT', 8 * 10 ** 9)
 
+SANDBOX_MIN_FALLBACK_TIMEOUT = os.environ.get('SANDBOX_MIN_FALLBACK_TIMEOUT', 60)
+
 
 class SandboxCommandError(Exception):
     """
@@ -49,6 +51,7 @@ class AutograderSandbox:
                  container_create_timeout: int=None,
                  pids_limit: int=SANDBOX_PIDS_LIMIT,
                  memory_limit: Union[int, str]=SANDBOX_MEM_LIMIT,
+                 min_fallback_timeout: int=SANDBOX_MIN_FALLBACK_TIMEOUT,
                  debug=False) -> None:
         """
         :param name: A human-readable name that can be used to identify
@@ -87,6 +90,9 @@ class AutograderSandbox:
             and using the max_num_processes argument to run_command
             if you want to impose a strict limit on a particular command.
 
+            The default value for this parameter can be changed by
+            setting the SANDBOX_PIDS_LIMIT environment variable.
+
         :param memory_limit: Passed to "docker create" with the --memory,
             --memory-swap, and --oom-kill-disable arguments. This will
             limit the amount of memory that processes running in the
@@ -102,8 +108,20 @@ class AutograderSandbox:
             argument to run_command to set a tighter limit on the command's
             address space size.
 
+            The default value for this parameter can be changed by
+            setting the SANDBOX_MEM_LIMIT environment variable.
+
             See https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory
             for more information.
+
+        :param min_fallback_timeout: The timeout argument to run_command
+            is primarily enforced by cmd_runner.py. When that argument is
+            not None, a timeout of either twice the timeout argument to
+            run_command or this value, whichever is larger, will be applied
+            to the subprocess call to cmd_runner.py itself.
+
+            The default value for this parameter can be changed by
+            setting the SANDBOX_MIN_FALLBACK_TIMEOUT environment variable.
 
         :param debug: Whether to print additional debugging information.
         """
@@ -120,6 +138,7 @@ class AutograderSandbox:
         self._container_create_timeout = container_create_timeout
         self._pids_limit = pids_limit
         self._memory_limit = memory_limit
+        self._min_fallback_timeout = min_fallback_timeout
         self.debug = debug
 
     def __enter__(self):
@@ -333,8 +352,11 @@ class AutograderSandbox:
             print('running: {}'.format(cmd), flush=True)
 
         with tempfile.TemporaryFile() as f:
+            fallback_timeout = (
+                max(timeout * 2, self._min_fallback_timeout) if timeout is not None else None)
             try:
-                subprocess.run(cmd, stdin=stdin, stdout=f, stderr=subprocess.PIPE, check=True)
+                subprocess.run(cmd, stdin=stdin, stdout=f, stderr=subprocess.PIPE,
+                               check=True, timeout=fallback_timeout)
                 f.seek(0)
 
                 json_len = int(f.readline().decode().rstrip())
@@ -365,6 +387,28 @@ class AutograderSandbox:
                         output=result.stdout, stderr=result.stderr)
 
                 return result
+            except subprocess.TimeoutExpired as e:
+                stdout_len = f.tell()
+                f.seek(0)
+                stdout = tempfile.NamedTemporaryFile()
+                for chunk in _chunked_read(f, stdout_len):
+                    stdout.write(chunk)
+                stdout.seek(0)
+
+                stderr = tempfile.NamedTemporaryFile()
+                stderr.write(b'The command exceeded the fallback timeout. '
+                             b'If this occurs frequently, contact your system administrator.\n')
+                stderr.write(e.stderr if isinstance(e.stderr, bytes) else e.stderr.read())
+                stderr.seek(0)
+
+                return CompletedCommand(
+                    return_code=None,
+                    timed_out=True,
+                    stdout=stdout,
+                    stderr=stderr,
+                    stdout_truncated=False,
+                    stderr_truncated=True,
+                )
             except subprocess.CalledProcessError as e:
                 f.seek(0)
                 stderr = e.stderr if isinstance(e.stderr, bytes) else e.stderr.read()

--- a/autograder_sandbox/autograder_sandbox.py
+++ b/autograder_sandbox/autograder_sandbox.py
@@ -5,7 +5,7 @@ import tarfile
 import tempfile
 import uuid
 from io import FileIO
-from typing import List
+from typing import List, Union
 
 import redis
 
@@ -15,6 +15,9 @@ SANDBOX_HOME_DIR_NAME = '/home/autograder'
 SANDBOX_WORKING_DIR_NAME = os.path.join(SANDBOX_HOME_DIR_NAME, 'working_dir')
 SANDBOX_USERNAME = 'autograder'
 SANDBOX_DOCKER_IMAGE = os.environ.get('SANDBOX_DOCKER_IMAGE', 'jameslp/ag-ubuntu-16:1')
+
+SANDBOX_PIDS_LIMIT = os.environ.get('SANDBOX_PIDS_LIMIT', 512)
+SANDBOX_MEM_LIMIT = os.environ.get('SANDBOX_MEM_LIMIT', 8 * 10 ** 9)
 
 
 class SandboxCommandError(Exception):
@@ -44,6 +47,8 @@ class AutograderSandbox:
                  allow_network_access: bool=False,
                  environment_variables: dict=None,
                  container_create_timeout: int=None,
+                 pids_limit: int=SANDBOX_PIDS_LIMIT,
+                 memory_limit: Union[int, str]=SANDBOX_MEM_LIMIT,
                  debug=False) -> None:
         """
         :param name: A human-readable name that can be used to identify
@@ -72,6 +77,34 @@ class AutograderSandbox:
             If the time limit is exceeded, subprocess.CalledProcessError
             will be raised. A value of None indicates no time limit.
 
+        :param pids_limit: Passed to "docker create" with the
+            --pids-limit flag. This will limit the number of processes
+            that can be created.
+            See https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/pids.html
+            for more information on limiting pids with cgroups.
+
+            We recommend leaving this value set to the default of 512
+            and using the max_num_processes argument to run_command
+            if you want to impose a strict limit on a particular command.
+
+        :param memory_limit: Passed to "docker create" with the --memory,
+            --memory-swap, and --oom-kill-disable arguments. This will
+            limit the amount of memory that processes running in the
+            sandbox can use.
+
+            We choose to disable the OOM killer to prevent the sandbox's
+            main process from being killed by the OOM killer (which would
+            cause the whole container to exit). This means, however, that
+            a command that hits the memory limit may time out.
+
+            In general we recommend setting this value as high as is safe
+            for your host machine and additionally using the max_virtual_memory
+            argument to run_command to set a tighter limit on the command's
+            address space size.
+
+            See https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory
+            for more information.
+
         :param debug: Whether to print additional debugging information.
         """
         if name is None:
@@ -85,6 +118,8 @@ class AutograderSandbox:
         self._environment_variables = environment_variables
         self._is_running = False
         self._container_create_timeout = container_create_timeout
+        self._pids_limit = pids_limit
+        self._memory_limit = memory_limit
         self.debug = debug
 
     def __enter__(self):
@@ -121,6 +156,11 @@ class AutograderSandbox:
             '-i',  # Run in interactive mode (for input redirection)
             '-t',  # Allocate psuedo tty
             '-d',  # Detached
+
+            '--pids-limit', str(self._pids_limit),
+            '--memory', str(self._memory_limit),
+            '--memory-swap', str(self._memory_limit),
+            '--oom-kill-disable',
         ]
 
         if not self.allow_network_access:

--- a/autograder_sandbox/autograder_sandbox.py
+++ b/autograder_sandbox/autograder_sandbox.py
@@ -111,7 +111,8 @@ class AutograderSandbox:
             The default value for this parameter can be changed by
             setting the SANDBOX_MEM_LIMIT environment variable.
 
-            See https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory
+            See https://docs.docker.com/config/containers/resource_constraints/\
+#limit-a-containers-access-to-memory
             for more information.
 
         :param min_fallback_timeout: The timeout argument to run_command

--- a/autograder_sandbox/docker-image-setup/cmd_runner.py
+++ b/autograder_sandbox/docker-image-setup/cmd_runner.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/python3
 
 import os
 import sys

--- a/autograder_sandbox/tests.py
+++ b/autograder_sandbox/tests.py
@@ -307,7 +307,6 @@ class AutograderSandboxMiscTestCase(unittest.TestCase):
     @mock.patch('subprocess.run')
     @mock.patch('subprocess.check_call')
     def test_container_create_timeout(self, mock_check_call, *args):
-        print(mock)
         with AutograderSandbox(debug=True):
             args, kwargs = mock_check_call.call_args
             self.assertIsNone(kwargs['timeout'])
@@ -725,7 +724,8 @@ class ContainerLevelResourceLimitTestCase(unittest.TestCase):
                 _PROCESS_SPAWN_PROG_TMPL.format(num_processes=1000, sleep_time=5), '.py', sandbox
             )
 
-            result = sandbox.run_command(['python3', filename])
+            # The limit should apply to all users, root or otherwise
+            result = sandbox.run_command(['python3', filename], as_root=True)
             stdout = result.stdout.read().decode()
             print(stdout)
             stderr = result.stderr.read().decode()
@@ -763,19 +763,56 @@ for i in range(2):
             print(result.stderr.read().decode())
             self.assertEqual(0, result.return_code)
 
-    def test_time_Limit(self) -> None:
-        # Figure out how to simulate the user bypassing cmd_runner's
-        # time limit
-        self.fail()
+    def test_fallback_time_limit_is_twice_timeout(self) -> None:
+        with AutograderSandbox(min_fallback_timeout=4) as sandbox:
+            mock_stderr = b'some stderr'
+            to_throw = subprocess.TimeoutExpired([], 10)
+            to_throw.stderr = mock_stderr
+            subprocess_run_mock = mock.Mock(side_effect=to_throw)
+            with mock.patch('subprocess.run', new=subprocess_run_mock):
+                result = sandbox.run_command(['sleep', '20'], timeout=5)
+                stdout = result.stdout.read().decode()
+                stderr = result.stderr.read().decode()
+                print(stdout)
+                print(stderr)
+
+                args, kwargs = subprocess_run_mock.call_args
+                self.assertEqual(10, kwargs['timeout'])
+
+                self.assertTrue(result.timed_out)
+                self.assertIsNone(result.return_code)
+                self.assertIn('fallback timeout', stderr)
+                self.assertIn(mock_stderr.decode(), stderr)
+
+    def test_fallback_time_limit_is_min_fallback_timeout(self) -> None:
+        with AutograderSandbox(min_fallback_timeout=60) as sandbox:
+            mock_stderr = b'some stderr'
+            to_throw = subprocess.TimeoutExpired([], 60)
+            to_throw.stderr = mock_stderr
+            subprocess_run_mock = mock.Mock(side_effect=to_throw)
+            with mock.patch('subprocess.run', new=subprocess_run_mock):
+                result = sandbox.run_command(['sleep', '20'], timeout=10)
+                stdout = result.stdout.read().decode()
+                stderr = result.stderr.read().decode()
+
+                args, kwargs = subprocess_run_mock.call_args
+                self.assertEqual(60, kwargs['timeout'])
+
+                self.assertTrue(result.timed_out)
+                self.assertIsNone(result.return_code)
+                self.assertIn('fallback timeout', stderr)
+                self.assertIn(mock_stderr.decode(), stderr)
 
     # Since we disable the OOM killer for the container, we expect
-    # commands to time out while waiting for memory to be made available.
+    # commands to time out while waiting for memory to be paged
+    # in and out.
     def test_memory_limit_no_oom_kill(self) -> None:
         program_str = _HEAP_USAGE_PROG_TMPL.format(num_bytes_on_heap=4 * 10 ** 9, sleep_time=0)
         with AutograderSandbox(memory_limit=2 * 10 ** 9) as sandbox:
             filename = _add_string_to_sandbox_as_file(program_str, '.cpp', sandbox)
             exe_name = _compile_in_sandbox(sandbox, filename)
-            result = sandbox.run_command(['./' + exe_name], timeout=20)
+            # The limit should apply to all users, root or otherwise
+            result = sandbox.run_command(['./' + exe_name], timeout=20, as_root=True)
 
             print(result.return_code)
             print(result.stdout.read().decode())

--- a/autograder_sandbox/tests.py
+++ b/autograder_sandbox/tests.py
@@ -598,16 +598,22 @@ def _run_stack_usage_prog(mem_to_use, mem_limit, sandbox):
 
 _STACK_USAGE_PROG_TMPL = """#include <iostream>
 #include <thread>
+#include <cstring>
 
 using namespace std;
 
-int main()
-{{
+int main() {{
     char stacky[{num_bytes_on_stack}];
+    for (int i = 0; i < {num_bytes_on_stack} - 1; ++i) {{
+        stacky[i] = 'a';
+    }}
+    stacky[{num_bytes_on_stack} - 1] = '\\0';
 
+    cout << "Sleeping" << endl;
     this_thread::sleep_for(chrono::seconds(2));
 
-    cout << stacky << endl;
+    cout << "Allocated " << strlen(stacky) + 1 << " bytes" << endl;
+
     return 0;
 }}
 """
@@ -615,7 +621,7 @@ int main()
 
 def _run_heap_usage_prog(mem_to_use, mem_limit, sandbox):
     def _run_prog(sandbox):
-        prog = _HEAP_USAGE_PROG_TMPL.format(num_bytes_on_heap=mem_to_use)
+        prog = _HEAP_USAGE_PROG_TMPL.format(num_bytes_on_heap=mem_to_use, sleep_time=2)
         filename = _add_string_to_sandbox_as_file(prog, '.cpp', sandbox)
         exe_name = _compile_in_sandbox(sandbox, filename)
         result = result = sandbox.run_command(
@@ -628,16 +634,24 @@ def _run_heap_usage_prog(mem_to_use, mem_limit, sandbox):
 
 _HEAP_USAGE_PROG_TMPL = """#include <iostream>
 #include <thread>
+#include <cstring>
 
 using namespace std;
 
-int main()
-{{
-    char* heapy = new char[{num_bytes_on_heap}];
+const size_t num_bytes_on_heap = {num_bytes_on_heap};
 
-    this_thread::sleep_for(chrono::seconds(2));
+int main() {{
+    cout << "Allocating an array of " << num_bytes_on_heap << " bytes" << endl;
+    char* heapy = new char[num_bytes_on_heap];
+    for (size_t i = 0; i < num_bytes_on_heap - 1; ++i) {{
+        heapy[i] = 'a';
+    }}
+    heapy[num_bytes_on_heap - 1] = '\\0';
 
-    cout << heapy << endl;
+    cout << "Sleeping" << endl;
+    this_thread::sleep_for(chrono::seconds({sleep_time}));
+
+    cout << "Allocated and filled " << strlen(heapy) + 1 << " bytes" << endl;
     return 0;
 }}
 """
@@ -646,7 +660,7 @@ int main()
 def _compile_in_sandbox(sandbox, *files_to_compile):
     exe_name = 'prog'
     sandbox.run_command(
-        ['g++', '--std=c++11'] + list(files_to_compile)
+        ['g++', '--std=c++11', '-Wall', '-Werror'] + list(files_to_compile)
         + ['-o', exe_name], check=True)
     return exe_name
 
@@ -655,7 +669,9 @@ def _run_process_spawning_prog(num_processes_to_spawn, process_limit,
                                sandbox):
     def _run_prog(sandbox):
         prog = _PROCESS_SPAWN_PROG_TMPL.format(
-            num_processes=num_processes_to_spawn)
+            num_processes=num_processes_to_spawn,
+            sleep_time=2
+        )
         filename = _add_string_to_sandbox_as_file(prog, '.py', sandbox)
 
         result = sandbox.run_command(['python3', filename],
@@ -672,10 +688,10 @@ import subprocess
 
 processes = []
 for i in range({num_processes}):
-    proc = subprocess.Popen(['sleep', '2'])
+    proc = subprocess.Popen(['sleep', '{sleep_time}'])
     processes.append(proc)
 
-time.sleep(2)
+time.sleep({sleep_time})
 
 for proc in processes:
     proc.communicate()
@@ -699,6 +715,72 @@ def _call_function_and_allocate_sandbox_if_needed(func, sandbox):
     else:
         return func(sandbox)
 
+# -----------------------------------------------------------------------------
+
+
+class ContainerLevelResourceLimitTestCase(unittest.TestCase):
+    def test_pid_limit(self) -> None:
+        with AutograderSandbox() as sandbox:
+            filename = _add_string_to_sandbox_as_file(
+                _PROCESS_SPAWN_PROG_TMPL.format(num_processes=1000, sleep_time=5), '.py', sandbox
+            )
+
+            result = sandbox.run_command(['python3', filename])
+            stdout = result.stdout.read().decode()
+            print(stdout)
+            stderr = result.stderr.read().decode()
+            print(stderr)
+            self.assertNotEqual(0, result.return_code)
+            self.assertIn('BlockingIOError', stderr)
+            self.assertIn('Resource temporarily unavailable', stderr)
+
+    def test_processes_created_and_finish_then_more_processes_spawned(self) -> None:
+        spawn_twice_prog = """
+import time
+import subprocess
+
+
+for i in range(2):
+    processes = []
+    print('spawing processes')
+    for i in range({num_processes}):
+        proc = subprocess.Popen(['sleep', '{sleep_time}'])
+        processes.append(proc)
+
+    time.sleep({sleep_time})
+
+    print('waiting for processes to finish')
+    for proc in processes:
+        proc.communicate()
+"""
+        with AutograderSandbox() as sandbox:
+            filename = _add_string_to_sandbox_as_file(
+                spawn_twice_prog.format(num_processes=350, sleep_time=5), '.py', sandbox
+            )
+
+            result = sandbox.run_command(['python3', filename])
+            print(result.stdout.read().decode())
+            print(result.stderr.read().decode())
+            self.assertEqual(0, result.return_code)
+
+    def test_time_Limit(self) -> None:
+        # Figure out how to simulate the user bypassing cmd_runner's
+        # time limit
+        self.fail()
+
+    # Since we disable the OOM killer for the container, we expect
+    # commands to time out while waiting for memory to be made available.
+    def test_memory_limit_no_oom_kill(self) -> None:
+        program_str = _HEAP_USAGE_PROG_TMPL.format(num_bytes_on_heap=4 * 10 ** 9, sleep_time=0)
+        with AutograderSandbox(memory_limit=2 * 10 ** 9) as sandbox:
+            filename = _add_string_to_sandbox_as_file(program_str, '.cpp', sandbox)
+            exe_name = _compile_in_sandbox(sandbox, filename)
+            result = sandbox.run_command(['./' + exe_name], timeout=20)
+
+            print(result.return_code)
+            print(result.stdout.read().decode())
+            print(result.stderr.read().decode())
+            self.assertTrue(result.timed_out)
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Implications of this are:
- System resources (time, processes, memory) will not be exhausted even if the user circumvents cmd_runner.py's limits. This gives us more flexibility in letting autograder users use custom images.
- The autograder could default to a higher (or no) process limit when calling AutograderSandbox.run_command.

Fixes #27 

