### PR TITLE
Changed TemporaryFile to NamedTemporaryFile in cmd_runner.py.

### DIFF
--- a/autograder_sandbox/autograder_sandbox.py
+++ b/autograder_sandbox/autograder_sandbox.py
@@ -160,11 +160,7 @@ class AutograderSandbox:
 
     def restart(self):
         """
-        Restarts the sandbox without destroying it. As a side effect,
-        this will kill any processes running inside the sandbox.
-
-        IMPORTANT: It is strongly recommended that you call this method
-        after a command run by run_command times out.
+        Restarts the sandbox without destroying it.
         """
         self._stop()
         subprocess.check_call(['docker', 'start', self.name])

--- a/autograder_sandbox/output_size_performance_test.py
+++ b/autograder_sandbox/output_size_performance_test.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import time
 
-from autograder_sandbox import AutograderSandbox, SandboxCommandError, VERSION
+from autograder_sandbox import AutograderSandbox, SandboxCommandError
 
 
 def main():

--- a/autograder_sandbox/tests.py
+++ b/autograder_sandbox/tests.py
@@ -15,7 +15,6 @@ from collections import OrderedDict
 from autograder_sandbox import (
     AutograderSandbox,
     SandboxCommandError,
-    VERSION,
     SANDBOX_USERNAME,
     SANDBOX_HOME_DIR_NAME,
     SANDBOX_DOCKER_IMAGE,


### PR DESCRIPTION
This lets us use os.path.size() instead of file.tell() to determine stdout and stderr length. This in turn
avoids an issue where valgrind core dumps cause a too-large output size to be produced.