### PR TITLE
Removed max_num_processes param from AutograderSandbox.run_command.

### DIFF
--- a/autograder_sandbox/autograder_sandbox.py
+++ b/autograder_sandbox/autograder_sandbox.py
@@ -272,7 +272,6 @@ class AutograderSandbox:
 
     def run_command(self,
                     args: List[str],
-                    max_num_processes: Optional[int] = None,
                     max_stack_size: Optional[int] = None,
                     max_virtual_memory: Optional[int] = None,
                     as_root: bool = False,
@@ -286,9 +285,6 @@ class AutograderSandbox:
 
         :param args: A list of strings that specify which command should
             be run inside the sandbox.
-
-        :param max_num_processes: The maximum number of processes the
-            command is allowed to spawn.
 
         :param max_stack_size: The maximum stack size, in bytes, allowed
             for the command.
@@ -317,9 +313,6 @@ class AutograderSandbox:
 
         if stdin is None:
             cmd.append('--stdin_devnull')
-
-        if max_num_processes is not None:
-            cmd += ['--max_num_processes', str(max_num_processes)]
 
         if max_stack_size is not None:
             cmd += ['--max_stack_size', str(max_stack_size)]

--- a/autograder_sandbox/docker-image-setup/cmd_runner.py
+++ b/autograder_sandbox/docker-image-setup/cmd_runner.py
@@ -124,7 +124,6 @@ def main():
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--timeout", type=int)
-    parser.add_argument("--max_num_processes", type=int)
     parser.add_argument("--max_stack_size", type=int)
     parser.add_argument("--max_virtual_memory", type=int)
     parser.add_argument("--truncate_stdout", type=int)

--- a/autograder_sandbox/tests.py
+++ b/autograder_sandbox/tests.py
@@ -170,7 +170,6 @@ class AutograderSandboxMiscTestCase(unittest.TestCase):
         with AutograderSandbox() as sandbox:
             result = sandbox.run_command(
                 ['python3', '-c', "import sys; sys.stdin.read(); print('done')"],
-                max_num_processes=10,
                 max_stack_size=10000000,
                 max_virtual_memory=500000000,
                 timeout=2,


### PR DESCRIPTION
Removed --max_num_processes flag from cmd_runner.py.

Fixes #41