### PR TITLE
Added block_process_spawn option to AutograderSandbox.run_command().

### DIFF
--- a/autograder_sandbox/autograder_sandbox.py
+++ b/autograder_sandbox/autograder_sandbox.py
@@ -272,6 +272,7 @@ class AutograderSandbox:
 
     def run_command(self,
                     args: List[str],
+                    block_process_spawn: bool = False,
                     max_stack_size: Optional[int] = None,
                     max_virtual_memory: Optional[int] = None,
                     as_root: bool = False,
@@ -285,6 +286,9 @@ class AutograderSandbox:
 
         :param args: A list of strings that specify which command should
             be run inside the sandbox.
+
+        :param block_process_spawn: If true, prevent the command from
+            spawning child processes by setting the nproc limit to 0.
 
         :param max_stack_size: The maximum stack size, in bytes, allowed
             for the command.
@@ -313,6 +317,9 @@ class AutograderSandbox:
 
         if stdin is None:
             cmd.append('--stdin_devnull')
+
+        if block_process_spawn:
+            cmd += ['--block_process_spawn']
 
         if max_stack_size is not None:
             cmd += ['--max_stack_size', str(max_stack_size)]

--- a/autograder_sandbox/docker-image-setup/cmd_runner.py
+++ b/autograder_sandbox/docker-image-setup/cmd_runner.py
@@ -27,6 +27,9 @@ def main():
                 os.setgid(grp.getgrnam('autograder').gr_gid)
                 os.setuid(pwd.getpwnam('autograder').pw_uid)
 
+            if args.block_process_spawn:
+                resource.setrlimit(resource.RLIMIT_NPROC, (0, 0))
+
             if args.max_stack_size is not None:
                 resource.setrlimit(
                     resource.RLIMIT_STACK,
@@ -124,6 +127,7 @@ def main():
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--timeout", type=int)
+    parser.add_argument("--block_process_spawn", action='store_true', default=False)
     parser.add_argument("--max_stack_size", type=int)
     parser.add_argument("--max_virtual_memory", type=int)
     parser.add_argument("--truncate_stdout", type=int)


### PR DESCRIPTION
When True, sets an nproc limit of 0 for the command.

Note that an nproc limit of 0 does NOT have the problem of processes in multiple containers with the same UID counting towards the same limit. Since the limit is 0, no process spawning is allowed to begin with.

Related to #41 